### PR TITLE
Quitar animación a imágenes

### DIFF
--- a/src/assets/js/darkMode.js
+++ b/src/assets/js/darkMode.js
@@ -37,23 +37,4 @@ document.addEventListener("DOMContentLoaded", function () {
         }
       }
     });
-
-  const imagen = document.getElementById("cursos");
-  const cargarImagen = (entradas, observador) => {
-    entradas.forEach((entrada) => {
-      if (entrada.isIntersecting) {
-        entrada.target.classList.add("visible");
-      } else {
-        entrada.target.classList.remove("visible");
-      }
-    });
-  };
-
-  const observador = new IntersectionObserver(cargarImagen, {
-    root: null,
-    rootMargin: "0px 0px 0px 0px",
-    threshold: 0.3,
-  });
-
-  observador.observe(imagen);
 });


### PR DESCRIPTION
**Fecha:** 02/04/2024
**Autor:** @AlexRGB2 
**Descripción:**
- Se eliminó la parte que animaba las imágenes del Home al hacer Scroll.